### PR TITLE
Some small splici script modifications

### DIFF
--- a/R/splici.R
+++ b/R/splici.R
@@ -1,22 +1,22 @@
 
-make_splici_txome <- function(gtf_path, 
-                              genome_path, 
-                              read_length, 
-                              flank_trim_length = 5, 
-                              output_dir, 
+make_splici_txome <- function(gtf_path,
+                              genome_path,
+                              read_length,
+                              flank_trim_length = 5,
+                              output_dir,
                               extra_spliced=NULL,
                               extra_unspliced=NULL,
                               dedup_seqs=FALSE) {
   # if you get some error from .get_cds_IDX, please try to rerun the code again
   # read length is the scRNA-seq read length
-  # flank trim length is used to avoid marginal case when dealing with junctional reads 
+  # flank trim length is used to avoid marginal case when dealing with junctional reads
   # assumes the following packages have been imported
   # eisaR, Biostrings, BSgenome, dplyr, stringr
-  
+
   ########################################################################################################
   # Preprocessing
   ########################################################################################################
-  
+
   suppressPackageStartupMessages({
     library(eisaR)
     library(Biostrings)
@@ -24,10 +24,10 @@ make_splici_txome <- function(gtf_path,
     library(stringr)
     library(GenomicFeatures)
   })
-  
+
   if (!dir.exists(output_dir)) {
     dir.create(file.path(output_dir),recursive = TRUE, showWarnings = FALSE)
-  }  
+  }
   # make sure flank_length makes sense
   flank_length = read_length - flank_trim_length
   if (flank_length < 0 ){
@@ -37,112 +37,108 @@ make_splici_txome <- function(gtf_path,
   if (!file.exists(gtf_path)) {
     stop("The following file does not exist: \n", gtf_path)
   }
-  
+
   # make sure fasta file exist
   if (!file.exists(genome_path)) {
     stop("The following file does not exist: \n", genome_path)
   }
   file_name_prefix = paste0("transcriptome_splici_fl", flank_length)
-  
-  
+
+
   #########################################################################################################
   # Process gtf to get spliced and introns
   #########################################################################################################
-  message("============processing gtf to get spliced and introns============")  
-  # fl is the flank length, here we set it to 
-  # the read length - 5 
+  message("============processing gtf to get spliced and introns============")
+  # fl is the flank length, here we set it to
+  # the read length - 5
   grl <- suppressWarnings(getFeatureRanges(
     gtf = file.path(gtf_path),
-    featureType = c("spliced", "intron"), 
-    intronType = "separate", 
-    flankLength = flank_length, 
-    joinOverlappingIntrons = TRUE, 
+    featureType = c("spliced", "intron"),
+    intronType = "separate",
+    flankLength = flank_length,
+    joinOverlappingIntrons = TRUE,
     verbose = TRUE
   ))
-  
+
   #########################################################################################################
   # Get spliced related stuffs
   #########################################################################################################
-  
+
   # spliced ranges has no dash in it
-  spliced_grl = grl[sapply(strsplit(names(grl), "-"), length) == 1]
-  
+  spliced_grl = grl[str_detect(names(grl), "-", negate = TRUE)]
+
   #########################################################################################################
   # Get reduced introns
   #########################################################################################################
-  
+
   # identify all introns and convert to GRanges
-  intron_gr = unlist(grl[sapply(strsplit(names(grl), "-"), length) == 2])
+  intron_gr = unlist(grl[str_detect(names(grl), "-")])
   # group introns by gene, then collapse ovelaping ranges!
   intron_grl = reduce(split(intron_gr, intron_gr$gene_id))
-  
+
   # clean txp names and gene names
   intron_gr <- BiocGenerics::unlist(intron_grl)
   intron_gr$exon_rank <- 1L
-  intron_gr$transcript_id <- sapply(strsplit(names(intron_gr), "-"), function(x) x[1])
+  intron_gr$transcript_id <- word(names(intron_gr), 1, sep = '-')
   intron_gr$gene_id <- intron_gr$transcript_id
   intron_gr$type <- "exon"
-  intron_gr$transcript_id <- gsub(
-    paste0("-I", "."), "-I", 
-    make.unique(paste0(intron_gr$transcript_id, "-I")),
-    fixed = TRUE
-  )
+  intron_gr$transcript_id <- make.unique(paste0(intron_gr$transcript_id, "-I"), sep = '')
   intron_gr$gene_id <- paste0(intron_gr$gene_id, "-I")
   intron_gr$exon_id <- intron_gr$transcript_id
   names(intron_gr) <- NULL
-  mcols(intron_gr) <- 
-    S4Vectors::mcols(intron_gr)[, c("exon_id", "exon_rank", 
+  mcols(intron_gr) <-
+    S4Vectors::mcols(intron_gr)[, c("exon_id", "exon_rank",
                                     "transcript_id", "gene_id", "type")]
   # remake intron GRangesList
   intron_grl <- BiocGenerics::relist(intron_gr, lapply(
-    structure(seq_along(intron_gr), 
+    structure(seq_along(intron_gr),
               names = intron_gr$transcript_id), function(i) i))
-  
-  
+
+
   #########################################################################################################
   # extract sequences from genome
   #########################################################################################################
-  
-  message("============extracting spliced and intron sequences from genome============")  
-  
+
+  message("============extracting spliced and intron sequences from genome============")
+
   # load the genome sequence
   x <- Biostrings::readDNAStringSet(file.path(genome_path))
-  # fix the names
-  names(x) <- sapply(strsplit(names(x), " "), .subset, 1)
-  
-  
+  # get the first word as the name
+  names(x) <- word(names(x), 1)
+
+
   grl = c(spliced_grl, intron_grl)
-  
+
   # make sure introns don't out of boundary
   seqlevels(grl) <- seqlevels(x)
-  seqlengths(grl) <- suppressWarnings(seqlengths(x)) 
+  seqlengths(grl) <- suppressWarnings(seqlengths(x))
   grl <- trim(grl)
-  
+
   seqs <- GenomicFeatures::extractTranscriptSeqs(
     x = x,
     transcripts = grl
   )
-  
+
   # If having duplicated sequences, only keep one
   if(dedup_seqs) {
     seqs = unique(seqs)
     grl = grl[names(seqs)]
   }
-  
-  
+
+
   # save some space
   rm(x)
   #########################################################################################################
   # process final outputs
   #########################################################################################################
-  message("Writing outputs...")  
-  
+  message("Writing outputs...")
+
   df <- getTx2Gene(grl)
   write.table(df, file.path(output_dir, paste0(file_name_prefix, "_t2g.tsv")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE)
   df <- df %>%
-    dplyr::mutate(gene_id = stringr::word(gene_id, 1, sep = '-'),
-                  status = ifelse(stringr::str_detect(transcript_id, '-'), 'U', 'S'))
-  
+    dplyr::mutate(gene_id = word(gene_id, 1, sep = '-'),
+                  status = ifelse(str_detect(transcript_id, '-'), 'U', 'S'))
+
   writeXStringSet(seqs, file.path(output_dir, paste0(file_name_prefix, ".fa")), format = "fasta")
   write.table(df, file.path(output_dir, paste0(file_name_prefix, "_t2g_3col.tsv")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE)
 
@@ -168,7 +164,7 @@ make_splici_txome <- function(gtf_path,
       }
     }
   }
-  
+
   if (!is.null(extra_unspliced)) {
     if (!file.exists(extra_unspliced)) {
       warning("provided extra_sequences file does not exist, will ignore it")
@@ -191,8 +187,8 @@ make_splici_txome <- function(gtf_path,
     }
   }
 
-  
 
 
-  message("Done.")  
+
+  message("Done.")
 }

--- a/R/splici.R
+++ b/R/splici.R
@@ -38,11 +38,17 @@ make_splici_txome <- function(gtf_path,
     stop("The following file does not exist: \n", gtf_path)
   }
 
-  # make sure fasta file exist
+  # make sure fasta file exists
   if (!file.exists(genome_path)) {
     stop("The following file does not exist: \n", genome_path)
   }
+
+  # output file names
   file_name_prefix = paste0("transcriptome_splici_fl", flank_length)
+  out_fa <- file.path(output_dir, paste0(file_name_prefix, ".fa"))
+  out_t2g <- file.path(output_dir, paste0(file_name_prefix, "_t2g.tsv"))
+  out_t2g3col <- file.path(output_dir, paste0(file_name_prefix, "_t2g_3col.tsv"))
+
 
 
   #########################################################################################################
@@ -134,15 +140,15 @@ make_splici_txome <- function(gtf_path,
   message("Writing outputs...")
 
   df <- getTx2Gene(grl)
-  write.table(df, file.path(output_dir, paste0(file_name_prefix, "_t2g.tsv")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE)
+  write.table(df, out_t2g, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE)
   df <- df %>%
     dplyr::mutate(gene_id = word(gene_id, 1, sep = '-'),
                   status = ifelse(str_detect(transcript_id, '-'), 'U', 'S'))
 
-  writeXStringSet(seqs, file.path(output_dir, paste0(file_name_prefix, ".fa")), format = "fasta")
+  writeXStringSet(seqs, out_fa, format = "fasta")
   write.table(df, file.path(output_dir, paste0(file_name_prefix, "_t2g_3col.tsv")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE)
 
-  # optional: adding extra spliced and unspliced seuqneces from an fasta file
+  # optional: adding extra spliced and unspliced sequences from an fasta file
     if (!is.null(extra_spliced)) {
     if (!file.exists(extra_spliced)) {
       warning("provided extra_sequences file does not exist, will ignore it")
@@ -152,14 +158,14 @@ make_splici_txome <- function(gtf_path,
       close(fa)
       for (ln in lns) {
         if (startsWith(ln, ">")) {
-          # it is a header, write to t2g file and fasta file
+          # it is a header, write to t2g files and fasta file
           txp_name = gsub(">", "", ln)
-          write.table(matrix(c(txp_name, txp_name), nrow = 1), file = file.path(output_dir, paste0(file_name_prefix, "_t2g.tsv")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
-          write.table(matrix(c(txp_name, txp_name, "S"), nrow = 1), file = file.path(output_dir, paste0(file_name_prefix, "_t2g_3col.tsv")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
-          write.table(ln, file = file.path(output_dir, paste0(file_name_prefix, ".fa")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
+          write.table(matrix(c(txp_name, txp_name), nrow = 1), file = out_t2g, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
+          write.table(matrix(c(txp_name, txp_name, "S"), nrow = 1), file = out_t2g3col, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
+          write.table(ln, file = out_fa, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
         } else {
           # if not a header, just write to fasta file
-          write.table(ln, file = file.path(output_dir, paste0(file_name_prefix, ".fa")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
+          write.table(ln, file = out_fa, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
         }
       }
     }
@@ -176,12 +182,12 @@ make_splici_txome <- function(gtf_path,
         if (startsWith(ln, ">")) {
           # it is a header, write to t2g file and fasta file
           txp_name = gsub(">", "", ln)
-          write.table(matrix(c(txp_name, paste0(txp_name, "-U")), nrow = 1), file = file.path(output_dir, paste0(file_name_prefix, "_t2g.tsv")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
-          write.table(matrix(c(txp_name, txp_name, "U"), nrow = 1), file = file.path(output_dir, paste0(file_name_prefix, "_t2g_3col.tsv")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
-          write.table(ln, file = file.path(output_dir, paste0(file_name_prefix, ".fa")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
+          write.table(matrix(c(txp_name, paste0(txp_name, "-U")), nrow = 1), file = out_t2g, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
+          write.table(matrix(c(txp_name, txp_name, "U"), nrow = 1), file = out_t2g3col, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
+          write.table(ln, file = out_fa, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
         } else {
           # if not a header, just write to fasta file
-          write.table(ln, file = file.path(output_dir, paste0(file_name_prefix, ".fa")), sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
+          write.table(ln, file = out_fa, sep = "\t", row.names = FALSE, quote = FALSE, col.names = FALSE, append = TRUE)
         }
       }
     }


### PR DESCRIPTION
I was looking at the updated splici scripts, and saw a couple places where I thought some small simplifications might be useful. Mostly this is just applying `stringr` in a couple more places. 

I also moved some output file definitions to the top of the function to remove repetition.

One other change is removal of a number of trailing blank spaces, which the RStudio editor does automatically, so apologies for the extra noise in the PR!